### PR TITLE
Defer to service discoery in get_nginxhost_ip.py

### DIFF
--- a/get_nginxhost_ip.py
+++ b/get_nginxhost_ip.py
@@ -2,8 +2,18 @@
 
 import logging
 import os
+import socket
+import sys
 
 import docker
+
+try:
+    socket.getaddrinfo('geonode', '80')
+    logging.info("k8s service discovery enabled")
+    print "http://geonode:80"
+    sys.exit()
+except socket.gaierror as e:
+    logging.info("k8s service discovery not enabled, using docker-compose")
 
 client = docker.from_env()
 # print client.info()


### PR DESCRIPTION
This will add a few lines of python to defer to service discovery
in kubernetes. If http://geonode:80 is resolvable from the get-go,
then that will be deferred to and the script will exit. If not, the
rest of the logic which is key to running geonode with compose will
continue to run normally.

Signed-off-by: Cullen Taylor <mctaylor@us.ibm.com>