### PR TITLE
Update entrypoint.sh - escape blanks in a path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,7 +77,7 @@ else
 fi
 
 # backup geonode REST role service config.xml
-cp "${GEOSERVER_DATA_DIR}/security/role/geonode REST role service/config.xml" "${GEOSERVER_DATA_DIR}/security/role/geonode REST role service/config.xml.orig"
+cp "${GEOSERVER_DATA_DIR}/security/role/geonode\ REST\ role\ service/config.xml" "${GEOSERVER_DATA_DIR}/security/role/geonode REST role service/config.xml.orig"
 # run the setting script for geonode REST role service
 /usr/local/tomcat/tmp/set_geoserver_auth.sh "${GEOSERVER_DATA_DIR}/security/role/geonode REST role service/config.xml" "${GEOSERVER_DATA_DIR}/security/role/geonode REST role service/" ${TAGNAME} >> /usr/local/tomcat/tmp/set_geoserver_auth.log
 


### PR DESCRIPTION
it works fine on my machine (windows with wsl2) but on the azure-cloud I get this error:

> cp: cannot stat '/geoserver_data/data/security/role/geonode REST role service/config.xml': No such file or directory

think it comes from the non-escaped blanks in the folder: 'geonode REST role service' so please merge